### PR TITLE
Remove unused `#![feature(rustc_private)]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(rustc_private)]
-
 extern crate crossbeam_channel;
 extern crate rustracing;
 extern crate rustracing_jaeger;


### PR DESCRIPTION
I don't understand how that feature tag got there anyway...